### PR TITLE
fix(deployment): use api folder so vercel will work

### DIFF
--- a/api/index.ts
+++ b/api/index.ts
@@ -1,0 +1,3 @@
+import app from '../src/index'
+
+export default app

--- a/vercel.json
+++ b/vercel.json
@@ -2,14 +2,14 @@
   "version": 2,
   "builds": [
     {
-      "src": "src/index.ts",
+      "src": "api/index.ts",
       "use": "@vercel/node"
     }
   ],
   "rewrites": [
     {
       "source": "/(.*)",
-      "destination": "/src/index.ts"
+      "destination": "/api"
     }
   ]
 }


### PR DESCRIPTION
i still dont understand about this, but it seems vercel will look into api folder as default to build the functions, but if you want to put your routes directly in src/index.ts, we dont need api folder